### PR TITLE
Handle NotFoundException in event commands and controller

### DIFF
--- a/GloboTicket.TicketManagement.Api/Controllers/EventsController.cs
+++ b/GloboTicket.TicketManagement.Api/Controllers/EventsController.cs
@@ -63,6 +63,10 @@ namespace GloboTicket.TicketManagement.Api.Controllers
                 await mediator.Send(command);
                 return NoContent();
             }
+            catch(NotFoundException)
+            {
+                return NotFound();
+            }
             catch (ValidationException ex)
             {
                 return BadRequest(ex.Errors);
@@ -74,8 +78,15 @@ namespace GloboTicket.TicketManagement.Api.Controllers
         [ProducesDefaultResponseType]
         public async Task<ActionResult> DeleteEvent(Guid id)
         {
-            await mediator.Send(new DeleteEventCommand(id));
-            return NoContent();
+            try
+            {
+                await mediator.Send(new DeleteEventCommand(id));
+                return NoContent();
+            }
+            catch (NotFoundException)
+            {
+                return NotFound();
+            }
         }
 
         [HttpGet("export", Name = "ExportEvents")]

--- a/GloboTicket.TicketManagement.Application/Features/Events/Commands/DeleteEvent/DeleteEventCommandHandler.cs
+++ b/GloboTicket.TicketManagement.Application/Features/Events/Commands/DeleteEvent/DeleteEventCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using GloboTicket.TicketManagement.Application.Contracts.Persistence;
+using GloboTicket.TicketManagement.Application.Exceptions;
 using GloboTicket.TicketManagement.Domain.Entities;
 using MediatR;
 
@@ -11,6 +12,9 @@ public class DeleteEventCommandHandler(IEventRepository eventRepository)
     public async Task Handle(DeleteEventCommand request, CancellationToken cancellationToken)
     {
         var eventToDelete = await eventRepository.GetByIdAsync(request.EventId);
+        if (eventToDelete == null)
+            throw new NotFoundException(nameof(Event), request.EventId);
+
         await eventRepository.DeleteAsync(eventToDelete);
     }
 }

--- a/GloboTicket.TicketManagement.Application/Features/Events/Commands/UpdateEvent/UpdateEventCommandHandler.cs
+++ b/GloboTicket.TicketManagement.Application/Features/Events/Commands/UpdateEvent/UpdateEventCommandHandler.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using GloboTicket.TicketManagement.Application.Contracts.Persistence;
+using GloboTicket.TicketManagement.Application.Exceptions;
 using GloboTicket.TicketManagement.Domain.Entities;
 using MediatR;
 
@@ -11,7 +12,9 @@ public class UpdateEventCommandHandler(IEventRepository eventRepository, IMapper
     public async Task Handle(UpdateEventCommand request, CancellationToken cancellationToken)
     {
         var eventToUpdate = await eventRepository.GetByIdAsync(request.EventId);
-        
+        if(eventToUpdate == null)
+            throw new NotFoundException(nameof(Event), request.EventId);
+
         mapper.Map(request, eventToUpdate);
         await eventRepository.UpdateAsync(eventToUpdate);
     }


### PR DESCRIPTION
#### PR Classification
Bug fix to handle `NotFoundException` in event-related operations.

#### PR Summary
Updated the `EventsController` and command handlers to handle `NotFoundException` for better error handling.
- `EventsController`: Added `try-catch` blocks to return `NotFound` responses in two methods.
- `DeleteEventCommandHandler`: Now throws `NotFoundException` if the event is not found.
- `UpdateEventCommandHandler`: Now throws `NotFoundException` if the event is not found.
- Added necessary `using` statements for `NotFoundException` in `DeleteEventCommandHandler.cs` and `UpdateEventCommandHandler.cs`.
